### PR TITLE
Added name of error to be consumed in the Step Function

### DIFF
--- a/lib/step_functions/activity.rb
+++ b/lib/step_functions/activity.rb
@@ -343,6 +343,7 @@ module StepFunctions
           begin
             @states.send_task_failure(
               task_token: activity_task.task_token,
+              error: error.class.to_s,
               cause: error.message
             )
           rescue => e


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Sending the Error name in case of Custom Error raised during an Activity. The error name can then be handled downstream within the Step Function.

@jmnarloch 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
