### PR TITLE
Fix heartbeat api call

### DIFF
--- a/lib/step_functions/activity.rb
+++ b/lib/step_functions/activity.rb
@@ -372,7 +372,9 @@ module StepFunctions
       def send_heartbeat(token)
         StepFunctions.with_retries(max_retry: @max_retry) do
           begin
-            @states.send_task_heartbeat(token)
+            @states.send_task_heartbeat(
+              task_token: token
+            )
           rescue => e
             @logger.error('Failed to send heartbeat for activity')
             @logger.error(e)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/States/Client.html#send_task_heartbeat-instance_method

send_task_heartbeat takes a Hash of `{ task_token: token }` not a String of the token itself. This is true for both the aws ruby sdk version 3 and 2. 

I could not send heartbeats when running this script due to this issue. I tried this fix and confirmed that it works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
